### PR TITLE
Added in player stats, mobs now show damage of kill attack

### DIFF
--- a/Items/Weapons.py
+++ b/Items/Weapons.py
@@ -3,12 +3,20 @@ WEAPONS = {
         "Range": 200,
         "Speed": 500,
         "Damage": 25,
-        "Arc": 45
+        "Arc": 45,
+        "STR": 2,
+        "INT": 0,
+        "DEX": 1,
+        "HASTE": 5,
+        "MASTERY": 0,
     },
     "Bow": {
-        "Range": 2000,
         "Speed": 500,
         "Damage": 25,
-        "Arc": 45
+        "STR": 1,
+        "INT": 0,
+        "DEX": 2,
+        "HASTE": 5,
+        "MASTERY": 0,
     }
 }

--- a/Main.py
+++ b/Main.py
@@ -133,8 +133,8 @@ class Game:
         for tile_object in self.map.tmxdata.objects:
             object_center = vec(tile_object.x + tile_object.width / 2, tile_object.y + tile_object.height / 2)
             if tile_object.name == "Player":
-                # self.player = Knight(self, object_center.x, object_center.y)
-                self.player = Ranger(self, object_center.x, object_center.y)
+                self.player = Knight(self, object_center.x, object_center.y)
+                # self.player = Ranger(self, object_center.x, object_center.y)
                 logging.debug("Placing Player Sprite")
             elif tile_object.name == "Mob":
                 Mob(self, object_center.x, object_center.y)

--- a/Player/PlayerData.py
+++ b/Player/PlayerData.py
@@ -25,7 +25,9 @@ PLAYER = {
     },
     "Level Up": {
         "Exp Required": 5,
-        "Dmg Increase": 1.1, # Percentage increase
+        "STR Increase": 1,
+        "DEX Increase": 1,
+        "INT Increase": 1,
         "Health Increase": 5
     }
 }


### PR DESCRIPTION
Stats are: Strength, Dexterity, Intellect, Haste, and Mastery

For knight: Damage is calculated by: damage = int(self.damage * self.strength / 10 * ability_modifier)
For ranger: Damage is calculated by: damage = int(self.damage * self.dexterity / 10 * ability_modifier)

currently the only stat of the major three that applies to each class is their primary

Haste increases attack speed and charge speed by 0.1% for each point. 
 - 10 haste is equivalent to 1%

Mastery currently does nothing

Each time a player levels up, STR, DEX, INT all increase by 1

Stats on gear (currently only the weapon equipped) is calculated on top of the base stats so that any equipment changes will be reflected accurately.

_________________________________________________________
Mob floating damage text modification
I changed the mob code so that when the mob takes lethal damage, they stay on the screen for .1 seconds and displays the damage of the last abililty that hit them
